### PR TITLE
2.0.0: Only audit nodes that have changed 

### DIFF
--- a/AuditQueue.js
+++ b/AuditQueue.js
@@ -1,0 +1,54 @@
+import { rIC as requestIdleCallback } from 'idlize/idle-callback-polyfills.mjs'
+
+export default class AuditQueue {
+  constructor() {
+    this._pendingAudits = []
+    this._isRunning = false
+
+    this.run = this.run.bind(this)
+    this._scheduleAudits = this._scheduleAudits.bind(this)
+  }
+  run(getAuditResult) {
+    // Returns a promise that resolves to the result of the auditCallback.
+    return new Promise((resolve, reject) => {
+      const runAudit = async () => {
+        try {
+          const result = await getAuditResult()
+          resolve(await result)
+        } catch (error) {
+          reject(error)
+        }
+      }
+
+      this._pendingAudits.push(runAudit)
+      if (!this._isRunning) this._scheduleAudits()
+    })
+  }
+  _scheduleAudits() {
+    this._isRunning = true
+    requestIdleCallback(async IdleDeadline => {
+      // Run pending audits as long as they exist & we have time.
+      while (
+        this._pendingAudits.length > 0 &&
+        IdleDeadline.timeRemaining() > 0
+      ) {
+        // Only run one audit at a time, as axe-core does not allow for
+        // concurrent runs.
+        // Ref: https://github.com/dequelabs/axe-core/issues/1041
+        const runAudit = this._pendingAudits[0]
+        await runAudit()
+
+        // Once an audit has run, remove it from the queue.
+        this._pendingAudits.shift()
+      }
+
+      if (this._pendingAudits.length > 0) {
+        // If pending audits remain, schedule them for the next idle phase.
+        this._scheduleAudits()
+      } else {
+        // The queue is empty, we're no longer running
+        this._isRunning = false
+      }
+    })
+  }
+}

--- a/AxeObserver.js
+++ b/AxeObserver.js
@@ -1,18 +1,5 @@
 import axeCore from 'axe-core'
-import PQueue from 'p-queue'
-
-// If requestIdleCallback is not supported, we fallback to setTimeout
-// Ref: https://developers.google.com/web/updates/2015/08/using-requestidlecallback
-const requestIdleCallback =
-  window.requestIdleCallback ||
-  function(callback) {
-    setTimeout(callback, 1)
-  }
-
-// axe-core cannot be run concurrently. There are no plans to implement this
-// functionality or a queue. Hence we use PQueue to queue calls ourselves.
-// Ref: https://github.com/storybookjs/storybook/pull/4086
-const axeQueue = new PQueue({ concurrency: 1 })
+import AuditQueue from './AuditQueue.js'
 
 // The AxeObserver class takes a violationsCallback, which is invoked with an
 // array of observed violations.
@@ -45,14 +32,17 @@ export default class AxeObserver {
 
     this.observe = this.observe.bind(this)
     this.disconnect = this.disconnect.bind(this)
-    this._scheduleAudit = this._scheduleAudit.bind(this)
+    this._auditNode = this._auditNode.bind(this)
 
     this._alreadyReportedIncidents = new Set()
     this._mutationObserver = new window.MutationObserver(mutationRecords => {
       mutationRecords.forEach(mutationRecord => {
-        this._scheduleAudit(mutationRecord.target)
+        this._auditNode(mutationRecord.target)
       })
     })
+
+    // AuditQueue sequentially runs audits when the browser is idle.
+    this._auditQueue = new AuditQueue()
 
     // Allow for registering plugins etc
     if (typeof axeInstanceCallback === 'function') {
@@ -73,27 +63,17 @@ export default class AxeObserver {
     })
 
     // run initial audit on the whole targetNode
-    this._scheduleAudit(targetNode)
+    this._auditNode(targetNode)
   }
   disconnect() {
     this.mutationObserver.disconnect()
   }
-  async _scheduleAudit(node) {
-    const response = await axeQueue.add(
-      () =>
-        new Promise(resolve => {
-          requestIdleCallback(
-            () => {
-              // Since audits are scheduled asynchronously, it can happen that
-              // the node is no longer connected. We cannot analyze it then.
-              node.isConnected ? axeCore.run(node).then(resolve) : resolve(null)
-            },
-            // Time after which an audit will be performed, even if it may
-            // negatively affect performance.
-            { timeout: 1000 }
-          )
-        })
-    )
+  async _auditNode(node) {
+    const response = await this._auditQueue.run(async () => {
+      // Since audits are scheduled asynchronously, it can happen that
+      // the node is no longer connected. We cannot analyze it then.
+      return node.isConnected ? axeCore.run(node) : null
+    })
 
     if (!response) return
 

--- a/README.MD
+++ b/README.MD
@@ -9,7 +9,7 @@ You can install the module from NPM via (`npm install --save-dev agnostic-axe`) 
 ## Usage
 
 ```js
-import('https://unpkg.com/agnostic-axe@1').then(
+import('https://unpkg.com/agnostic-axe@2').then(
   ({ AxeObserver, logViolations }) => {
     const MyAxeObserver = new AxeObserver(logViolations)
     MyAxeObserver.observe(document)

--- a/README.MD
+++ b/README.MD
@@ -46,7 +46,7 @@ The `AxeObserver` constructor takes two parameters:
   - `axeCoreConfiguration` (optional). A configuration object for axe-core. Read about the object here in the [axe-core docs](https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axeconfigure) and see the `agnostic-axe` source code for the default options used.
   - `axeCoreInstanceCallback` (optional). A function that is invoked with the instance of [axe-core](https://github.com/dequelabs/axe-core) used by module. It can be used for complex interactions with the [axe-core API](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md) such as registering plugins.
 
-The `AxeObserver.observe` method takes two parameters:
+The `AxeObserver.observe` method takes one parameter:
 
 - `targetNode` (required). The node that should be observed & analyzed.
 

--- a/README.MD
+++ b/README.MD
@@ -19,7 +19,7 @@ import('https://unpkg.com/agnostic-axe@2').then(
 
 > Be sure to only run the module in your development environment. Else your application will use more resources than necessary when in production.
 
-In the example above, once the `observe` method has been invoked, `MyAxeObserver` starts reporting accessibility defects to the browser console. It continously observes the passed node for changes. If a change has been detected, it will reanalyze the node and report any new accessibility defects.
+In the example above, once the `observe` method has been invoked, `MyAxeObserver` audits the passed node and reports any accessibility defects to the browser console. It continously observes the passed node for changes. If a change has been detected, it will audit the parts of the nodes that have changed, and report any new accessibility defects.
 
 To observe multiple nodes, one can call the `observe` method multiple times.
 
@@ -49,9 +49,6 @@ The `AxeObserver` constructor takes two parameters:
 The `AxeObserver.observe` method takes two parameters:
 
 - `targetNode` (required). The node that should be observed & analyzed.
-- `options` (optional). An object with that supports the following configuration keys:
-  - `debounceMs` (optional, defaults to `1000`). The number of milliseconds that updates should cease before an analysis is performed.
-  - `maxWaitMs` (optional, defaults to `debounceMs * 5`). Number of milliseconds after which an analysis will be performed, even if the targetNode is still updating.
 
 ## Credits
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "agnostic-axe",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2160,11 +2160,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
-    },
     "execa": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
@@ -2720,6 +2715,11 @@
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
       "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
       "dev": true
+    },
+    "idlize": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/idlize/-/idlize-0.1.1.tgz",
+      "integrity": "sha512-G4Qgr53MHUwT0JGXP5asyy+4ztcNDkFQKB+MWRRxsQ9LqAf0RWLKk+QU20u3cUAsndQfTMO6F19i5xZm9/8c5A=="
     },
     "ignore": {
       "version": "3.3.10",
@@ -4531,7 +4531,8 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-locate": {
       "version": "2.0.0",
@@ -4564,23 +4565,6 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
-    },
-    "p-queue": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.2.1.tgz",
-      "integrity": "sha512-wV8yC/rkuWpgu9LGKJIb48OynYSrE6lVl2Bx6r8WjbyVKrFAzzQ/QevAvwnDjlD+mLt8xy0LTDOU1freOvMTCg==",
-      "requires": {
-        "eventemitter3": "^4.0.0",
-        "p-timeout": "^3.1.0"
-      }
-    },
-    "p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "requires": {
-        "p-finally": "^1.0.0"
-      }
     },
     "parse-glob": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3819,11 +3819,6 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
     "lodash.foreach": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnostic-axe",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Framework agnostic accessibility auditing with axe-core",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   },
   "dependencies": {
     "axe-core": "^3.4.0",
-    "p-queue": "^6.2.1"
+    "idlize": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "axe-core": "^3.4.0",
-    "lodash.debounce": "^4.0.8",
     "p-queue": "^6.2.1"
   }
 }


### PR DESCRIPTION
Previously agnostic-axe would audit the whole observed node (usually the document) if a part of it changed. For larger pages this would be quite an intense operation, so audits were debounced for performance. 

This version now only audits the individual parts that have changed. Each node passed by the MutationObserver is audited individually. This means we have smaller chunks of work that better fit into the browsers idle period. In addition, less content has to be audited. 

To make this happen, this adds the `AuditQueue` class, which keeps a queue of pending audits and executes them during idle periods. Debouncing options have been removed. Audits are run as soon as the browser has idle time.